### PR TITLE
Improve coverage and clean the execution

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -67,9 +67,9 @@ jobs:
           test "$LANG" = "$CONFIG_LOCALE"
           test "$(cat ${ROOTFS_DIR}/etc/timezone)" = "$CONFIG_TIMEZONE"
 
-      - name: Remove test label from PR
+      - name: Remove test label from PR (if set)
         uses: actions-ecosystem/action-remove-labels@v1
-        if: always()
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'test') }}
         with:
           labels: test
 

--- a/__test__/configure.test.ts
+++ b/__test__/configure.test.ts
@@ -49,4 +49,15 @@ describe('Configure', () => {
       expect.not.stringContaining('secretpassword')
     )
   })
+
+  it('should fall back to default configuration values if no user settings present', async () => {
+    jest.spyOn(core, 'info').mockImplementation()
+    jest.spyOn(core, 'getInput').mockReturnValue('')
+    jest.spyOn(core, 'getBooleanInput').mockReturnValue(false)
+    jest.spyOn(config, 'validateConfig').mockReturnValue(Promise.resolve())
+
+    await configure()
+
+    expect(config.validateConfig).toHaveBeenCalledWith(config.DEFAULT_CONFIG)
+  })
 })

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 96,
-      branches: 79,
+      branches: 92,
       functions: 96,
       lines: 97
     }

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -9,48 +9,51 @@ export async function configure(): Promise<PiGenConfig> {
     const userConfig = DEFAULT_CONFIG
 
     userConfig.imgName = core.getInput('image-name', {required: true})
+
+    const stageList = core.getInput('stage-list').split(/\s+/)
     userConfig.stageList =
-      core.getInput('stage-list').split(/\s+/) ?? DEFAULT_CONFIG.stageList
-    userConfig.release = core.getInput('release') ?? DEFAULT_CONFIG.release
+      stageList.length > 0 ? stageList : DEFAULT_CONFIG.stageList
+
+    userConfig.release = core.getInput('release') || DEFAULT_CONFIG.release
     userConfig.deployCompression =
-      core.getInput('compression') ?? DEFAULT_CONFIG.deployCompression
+      core.getInput('compression') || DEFAULT_CONFIG.deployCompression
     userConfig.compressionLevel =
-      core.getInput('compression-level') ?? DEFAULT_CONFIG.compressionLevel
+      core.getInput('compression-level') || DEFAULT_CONFIG.compressionLevel
     userConfig.localeDefault =
-      core.getInput('locale') ?? DEFAULT_CONFIG.localeDefault
+      core.getInput('locale') || DEFAULT_CONFIG.localeDefault
     userConfig.targetHostname =
-      core.getInput('hostname') ?? DEFAULT_CONFIG.targetHostname
+      core.getInput('hostname') || DEFAULT_CONFIG.targetHostname
     userConfig.keyboardKeymap =
-      core.getInput('keyboard-keymap') ?? DEFAULT_CONFIG.keyboardKeymap
+      core.getInput('keyboard-keymap') || DEFAULT_CONFIG.keyboardKeymap
     userConfig.keyboardLayout =
-      core.getInput('keyboard-layout') ?? DEFAULT_CONFIG.keyboardLayout
+      core.getInput('keyboard-layout') || DEFAULT_CONFIG.keyboardLayout
     userConfig.timezoneDefault =
-      core.getInput('timezone') ?? DEFAULT_CONFIG.timezoneDefault
+      core.getInput('timezone') || DEFAULT_CONFIG.timezoneDefault
     userConfig.firstUserName =
-      core.getInput('username') ?? DEFAULT_CONFIG.firstUserName
+      core.getInput('username') || DEFAULT_CONFIG.firstUserName
     userConfig.firstUserPass =
-      core.getInput('password') ?? DEFAULT_CONFIG.firstUserPass
+      core.getInput('password') || DEFAULT_CONFIG.firstUserPass
     userConfig.disableFirstBootUserRename =
-      core.getInput('disable-first-boot-user-rename') ??
+      core.getInput('disable-first-boot-user-rename') ||
       DEFAULT_CONFIG.disableFirstBootUserRename
-    userConfig.wpaEssid = core.getInput('wpa-essid') ?? DEFAULT_CONFIG.wpaEssid
+    userConfig.wpaEssid = core.getInput('wpa-essid') || DEFAULT_CONFIG.wpaEssid
     userConfig.wpaPassword =
-      core.getInput('wpa-password') ?? DEFAULT_CONFIG.wpaPassword
+      core.getInput('wpa-password') || DEFAULT_CONFIG.wpaPassword
     userConfig.wpaCountry =
-      core.getInput('wpa-country') ?? DEFAULT_CONFIG.wpaCountry
+      core.getInput('wpa-country') || DEFAULT_CONFIG.wpaCountry
     userConfig.enableSsh =
-      core.getInput('enable-ssh') ?? DEFAULT_CONFIG.enableSsh
-    userConfig.useQcow2 = core.getInput('use-qcow2') ?? DEFAULT_CONFIG.useQcow2
+      core.getInput('enable-ssh') || DEFAULT_CONFIG.enableSsh
+    userConfig.useQcow2 = core.getInput('use-qcow2') || DEFAULT_CONFIG.useQcow2
     userConfig.enableNoobs =
-      core.getBooleanInput('enable-noobs').toString() ??
+      core.getBooleanInput('enable-noobs')?.toString() ||
       DEFAULT_CONFIG.enableNoobs
     userConfig.exportLastStageOnly =
-      core.getBooleanInput('export-last-stage-only').toString() ??
+      core.getBooleanInput('export-last-stage-only')?.toString() ||
       DEFAULT_CONFIG.exportLastStageOnly
     userConfig.dockerOpts = core.getInput('docker-opts')
-    userConfig.setfcap = core.getInput('setfcap') ?? DEFAULT_CONFIG.setfcap
+    userConfig.setfcap = core.getInput('setfcap') || DEFAULT_CONFIG.setfcap
     userConfig.piGenRelease =
-      core.getInput('pi-gen-release') ?? DEFAULT_CONFIG.piGenRelease
+      core.getInput('pi-gen-release') || DEFAULT_CONFIG.piGenRelease
 
     await validateConfig(userConfig)
 

--- a/src/pi-gen-config.ts
+++ b/src/pi-gen-config.ts
@@ -35,7 +35,7 @@ export interface PiGenConfig {
 export const DEFAULT_CONFIG: PiGenConfig = {
   imgName: 'test',
   piGenRelease: 'Raspberry Pi reference',
-  release: 'bullseye',
+  release: 'bookworm',
   deployCompression: 'zip',
   compressionLevel: '6',
   localeDefault: 'en_GB.UTF-8',
@@ -47,7 +47,7 @@ export const DEFAULT_CONFIG: PiGenConfig = {
   enableSsh: '0',
   pubkeyOnlySsh: '0',
   stageList: ['stage*'],
-  useQcow2: '1',
+  useQcow2: '0',
   enableNoobs: 'false',
   exportLastStageOnly: 'true'
 }


### PR DESCRIPTION
* adds `DEBIAN_FRONTEND=noninteractive` to `pi-gen` Docker executions
* detects messages written to `stderr` by Docker BuildKit and does not create warnings for those
* fixes a bug in the `pi-gen` directory validation
* improves code coverage and CI workflows