### PR TITLE
Remove QCOW2 build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,6 @@ tries to make sure the stage is respected and its changes are included in the fi
     # System timezone.
     timezone: Europe/London
 
-    # Use qcow2 images to reduce space and runtime requirements. _WARNING_: this is 
-    # broken on recent versions of `pi-gen` and destined to be removed entirely (see 
-    # https://github.com/RPi-Distro/pi-gen/pull/648).
-    use-qcow2: 0
-
     # Name of the initial user account.
     username: pi
 

--- a/action.yml
+++ b/action.yml
@@ -12,12 +12,6 @@ inputs:
     description: The release name to use in `/etc/issue.txt`. The default should only be used for official Raspberry Pi builds.
     required: false
     default: Raspberry Pi reference
-  use-qcow2:
-    description: |
-      Use qcow2 images to reduce space and runtime requirements.
-      _WARNING_: this is broken on recent versions of `pi-gen` and destined to be removed entirely (see https://github.com/RPi-Distro/pi-gen/pull/648).
-    required: false
-    default: 0
   setfcap:
     description: |
       Setting to `1` will prevent pi-gen from dropping the "capabilities" feature. Generating the root filesystem with capabilities enabled and running

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -43,7 +43,6 @@ export async function configure(): Promise<PiGenConfig> {
       core.getInput('wpa-country') || DEFAULT_CONFIG.wpaCountry
     userConfig.enableSsh =
       core.getInput('enable-ssh') || DEFAULT_CONFIG.enableSsh
-    userConfig.useQcow2 = core.getInput('use-qcow2') || DEFAULT_CONFIG.useQcow2
     userConfig.enableNoobs =
       core.getBooleanInput('enable-noobs')?.toString() ||
       DEFAULT_CONFIG.enableNoobs

--- a/src/pi-gen-config.ts
+++ b/src/pi-gen-config.ts
@@ -26,7 +26,6 @@ export interface PiGenConfig {
   pubkeyOnlySsh: string
   setfcap?: string
   stageList: string[]
-  useQcow2: string
   enableNoobs: string
   exportLastStageOnly: string
   dockerOpts?: string
@@ -47,7 +46,6 @@ export const DEFAULT_CONFIG: PiGenConfig = {
   enableSsh: '0',
   pubkeyOnlySsh: '0',
   stageList: ['stage*'],
-  useQcow2: '0',
   enableNoobs: 'false',
   exportLastStageOnly: 'true'
 }


### PR DESCRIPTION
`pi-gen` has dropped support for QCOW2 builds with https://github.com/RPi-Distro/pi-gen/pull/648. This removes the action's settings to prevent users from accidentally using it on recent versions of `pi-gen`.