### PR TITLE
Group pi-gen stage logs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,11 @@ jobs:
     - run: npm test
 
     - uses: codecov/codecov-action@v4
+      if: failure() || success()
       with:
         files: coverage/clover.xml,coverage/lcov.info
         flags: unittests
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - run: npm run lint
 

--- a/src/pi-gen-config.ts
+++ b/src/pi-gen-config.ts
@@ -67,8 +67,12 @@ export async function writeToFile(
             : config[prop as keyof PiGenConfig]
         }"`
     )
-    .join('\n')
-  return fs.writeFile(file, configContent)
+
+  // We're adding this as a default to the config so that it's going to be
+  // picked up by pi-gen as well in order to reduce log volume
+  configContent.push('DEBIAN_FRONTEND=noninteractive')
+
+  return fs.writeFile(file, configContent.join('\n'))
 }
 
 export async function validateConfig(config: PiGenConfig): Promise<void> {


### PR DESCRIPTION
Uses GitHub Actions log groups to partition output from `pi-gen` build stages. The groups will contain the logs if `verbose-output` is set to true, otherwise only contain errors or warnings.

Ideally, groups would be nested so that you can unfold the logs from sub stages like in a tree view. This is currently not possible but a feature request was raised at https://github.com/actions/toolkit/issues/1001. 