### PR TITLE
fix: use qemu-user-static with symlink for container binfmt support

### DIFF
--- a/__test__/install-dependencies.test.ts
+++ b/__test__/install-dependencies.test.ts
@@ -17,7 +17,7 @@ describe('Install host dependencies', () => {
       expect.arrayContaining(['test-package']),
       expect.anything()
     )
-    expect(exec.getExecOutput).toHaveBeenLastCalledWith(
+    expect(exec.getExecOutput).toHaveBeenCalledWith(
       expect.stringMatching(/.*sudo$/),
       expect.arrayContaining(['test-module']),
       expect.anything()

--- a/src/host-dependencies.ts
+++ b/src/host-dependencies.ts
@@ -1,4 +1,4 @@
 export const hostDependencies = {
-  packages: ['binfmt-support'],
+  packages: ['binfmt-support', 'qemu-user-static'],
   modules: ['binfmt_misc']
 }

--- a/src/install-dependencies.ts
+++ b/src/install-dependencies.ts
@@ -17,13 +17,17 @@ export async function installHostDependencies(
 
     const piGenDependencies = await resolvePiGenDependencies(piGenDirectory)
 
+    // qemu-user-binfmt conflicts with qemu-user-static on Ubuntu; we need the
+    // static package for F-flag binfmt_misc to work inside containers
     const installPackages = [
       ...new Set([
         ...hostDependencies.packages,
         ...packages.split(/[\s,]/),
         ...piGenDependencies
       ])
-    ].filter(p => p)
+    ]
+      .filter(p => p)
+      .filter(p => p !== 'qemu-user-binfmt')
     const hostModules = [
       ...new Set([...hostDependencies.modules, ...modules.split(/[\s,]/)])
     ].filter(m => m)
@@ -71,6 +75,19 @@ export async function installHostDependencies(
     execOutput = await exec.getExecOutput(
       sudoPath,
       ['modprobe', '-a', ...hostModules],
+      {silent: !verbose}
+    )
+
+    // qemu-user-static provides qemu-aarch64-static but build-docker.sh expects
+    // "qemu-aarch64" in PATH. Create symlink so the static binary is found.
+    execOutput = await exec.getExecOutput(
+      sudoPath,
+      [
+        'ln',
+        '-sf',
+        '/usr/bin/qemu-aarch64-static',
+        '/usr/local/bin/qemu-aarch64'
+      ],
       {silent: !verbose}
     )
 


### PR DESCRIPTION
build-docker.sh runs 'which qemu-aarch64' and registers that binary for binfmt_misc with the F (fix-binary) flag. On Ubuntu 24.04 runners:
- qemu-user-binfmt provides dynamic qemu-aarch64 (fails in containers because dynamic linker can't find shared libs in container rootfs)
- qemu-user-static provides static qemu-aarch64-static (works in any namespace since it has no shared lib dependencies)

Fix: install qemu-user-static and symlink qemu-aarch64 to the static binary. Filter qemu-user-binfmt from pi-gen deps (conflicts).