### PR TITLE
fix: exclude rootfs from work directory cache

### DIFF
--- a/src/work-dir-cache.ts
+++ b/src/work-dir-cache.ts
@@ -41,9 +41,12 @@ export class WorkDirCache {
         [
           'tar',
           '--use-compress-program=zstd -T0 -10 --long=31',
-          '--exclude=./*/rootfs/proc/*',
-          '--exclude=./*/rootfs/sys/*',
-          '--exclude=./*/rootfs/dev/*',
+          // Exclude rootfs directories from cache. pi-gen's export-image stage
+          // allocates a fixed-size image based on `du` of the rootfs, then runs
+          // dist-upgrade inside it. A stale cached rootfs causes the size estimate
+          // to be too small for upgraded packages (e.g. kernel + initramfs growth),
+          // resulting in "No space left on device" during image export.
+          '--exclude=./*/*/rootfs',
           '-cf',
           WORK_DIR_ARCHIVE,
           '-C',


### PR DESCRIPTION
## Problem

The `enable-pigen-cache` feature caches the pi-gen work directory including all `rootfs/` trees. When restored on a subsequent build, pi-gen's `export-image/prerun.sh` measures the stale rootfs with `du` to allocate a fixed-size image partition. Then `export-image/02-set-sources/01-run.sh` runs `apt-get dist-upgrade` inside the loop-mounted image — upgrading packages (especially kernel + initramfs) that have grown since the cache was saved. This exceeds the pre-allocated partition size:

```
zstd: error 70 : Write error : cannot write block : No space left on device
update-initramfs: failed for /boot/initrd.img-6.18.33+rpt-rpi-v8 with 1.
```

Observed on `ubuntu-24.04-arm` integration tests where the cached rootfs had kernel `6.18.29+rpt` (May 17) but `dist-upgrade` installed `6.18.33+rpt` (June 7), whose initramfs exceeded the 20% + 200MB margin.

Upstream: [RPi-Distro/pi-gen#784](https://github.com/RPi-Distro/pi-gen/issues/784)

## Fix

Exclude all `rootfs` directories from the work directory cache tarball (`--exclude=./*/*/rootfs`). This ensures pi-gen always rebuilds rootfs from scratch via `debootstrap`/`copy_previous`, so the `du` measurement reflects current package sizes and the partition allocation is correct.

The previous `proc/sys/dev` excludes used an incorrect glob depth (`./*/rootfs/...` vs the actual `./*/*/rootfs/...`) and were ineffective anyway since those virtual filesystems are empty at archive time.

## Trade-off

This significantly reduces the cache's value (rootfs was the bulk of cached content). The Docker layer cache still provides speedup for the container image build, but `debootstrap` and stage execution will run fresh each time. This is the correct trade-off until pi-gen fixes the underlying sizing issue upstream.